### PR TITLE
Guess at what’s needed here to also import authors.

### DIFF
--- a/functions/function1/jobs/loadJobInfo.js
+++ b/functions/function1/jobs/loadJobInfo.js
@@ -34,6 +34,7 @@ exports.load = function() {
         rssChannel.item.each(function (i, newJobItem){
           var jobPosting = {recordType: 'Job',
             fields: {
+              author: {value: newJobItem.author.text()},
               link: {value: newJobItem.link.text()},
               title: {value: newJobItem.title.text()},
               content: {value: newJobItem.description.text()},


### PR DESCRIPTION
Not sure if this works, but in theory this should be enough to create the js object with an author field, which then gets pushed to CloudKit… probably!